### PR TITLE
Highlightable

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,15 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/railscasts.min.css">
 
   <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
   <script src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/languages/javascript.min.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+
 
   <style media="screen">
     i { color: #d4d4d4; padding: 0 0.2em; }

--- a/week-10/index.html
+++ b/week-10/index.html
@@ -72,3 +72,8 @@
     <td>returns <code>false</code></td>
   </tr>
 </table>
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/railscasts.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/languages/javascript.min.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>

--- a/week-3/index.html
+++ b/week-3/index.html
@@ -256,3 +256,7 @@
 -->
 
 <link rel="stylesheet" href="../styles/all.css" media="screen" title="All styles" charset="utf-8">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/railscasts.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/languages/javascript.min.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>

--- a/week-4/index.html
+++ b/week-4/index.html
@@ -202,3 +202,7 @@ body.appendChild(anchor);</code></pre>
 
 <link rel="stylesheet" href="../styles/all.css" media="screen" title="All styles" charset="utf-8">
 <script type="text/javascript" src="../scripts/carousels.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/railscasts.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/languages/javascript.min.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>

--- a/week-5/index.html
+++ b/week-5/index.html
@@ -108,3 +108,7 @@
 
 <link rel="stylesheet" href="../styles/all.css" media="screen" title="All styles" charset="utf-8">
 <script type="text/javascript" src="../scripts/carousels.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/railscasts.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/languages/javascript.min.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>

--- a/week-6/index.html
+++ b/week-6/index.html
@@ -30,7 +30,7 @@
   Adding/changing an element's attribute:
 </h3>
 
-<pre><code>// If the element is already on the page:
+<pre><code class="JavaScript">// If the element is already on the page:
 var el = document.querySelector("img");
 el.setAttribute("src", "http://example.com/logo.png");
 
@@ -215,3 +215,8 @@ addElement("li", "ul", "Go grocery shopping...");
 
 <link rel="stylesheet" href="../styles/all.css" media="screen" title="All styles" charset="utf-8">
 <script type="text/javascript" src="../scripts/carousels.js"></script>
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/railscasts.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/languages/javascript.min.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>

--- a/week-6/index.html
+++ b/week-6/index.html
@@ -30,7 +30,7 @@
   Adding/changing an element's attribute:
 </h3>
 
-<pre><code class="JavaScript">// If the element is already on the page:
+<pre><code>// If the element is already on the page:
 var el = document.querySelector("img");
 el.setAttribute("src", "http://example.com/logo.png");
 

--- a/week-7/index.html
+++ b/week-7/index.html
@@ -122,3 +122,7 @@ xhr.send();
 
 <link rel="stylesheet" href="../styles/all.css" media="screen" title="All styles" charset="utf-8">
 <script type="text/javascript" src="../scripts/carousels.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/railscasts.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/languages/javascript.min.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>

--- a/week-8/index.html
+++ b/week-8/index.html
@@ -109,3 +109,8 @@
 
   cars[0]["name"] // => "Porsche"
 </code></pre>
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/railscasts.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/languages/javascript.min.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>

--- a/week-9/index.html
+++ b/week-9/index.html
@@ -99,3 +99,8 @@ function displayMovie(movie) {
 <pre><code>var fruits = ['apples','pears','oranges','kiwis'];<br>localStorage.setItem('fruits', JSON.stringify(fruits));<br><br>var storedFruits = JSON.parse(localStorage.getItem('fruits'));</code></pre>
 
 -->
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/railscasts.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/languages/javascript.min.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>


### PR DESCRIPTION
Hi Avand!

As you requested, here's a drop-in syntax code highlighter. Any page with the below cdn links and `<pre><code>` tags will activate syntax highlighting. I've updated the index pages of weeks 3 through 10 as those were pages with the relevant tags. 

```
<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/railscasts.min.css">
<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/highlight.min.js"></script>
<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/languages/javascript.min.js"></script>
<script>hljs.initHighlightingOnLoad();</script>
```

This was fun to fiddle with and a lot simpler than I was expecting. Happy new year!
